### PR TITLE
Fix parsing URL files which contain query string parameters

### DIFF
--- a/js/filelist.js
+++ b/js/filelist.js
@@ -506,8 +506,8 @@ var Files_Linkeditor = {
 			if(urllines && Array.isArray(urllines) && urllines.length > 0) {
 				// Let's use the first match.
 				var url = urllines[0];
-				// Return the part after the equal sign, which is suprisingly: the URL.
-				return sanitizeUrl((url.split('='))[1]);
+				// Return only the URL.
+				return sanitizeUrl(url.replace('URL=', ''));
 			}
 		}
 		return '';


### PR DESCRIPTION
Splitting the URL with '=' as the separator causes the loss of all query string parameters.

For example, https://www.youtube.com/watch?v=test will become https://www.youtube.com/watch?v.

Instead, we should do something like stripping the unwanted string ("URL=")