### PR TITLE
Add missing linkeditor.css

### DIFF
--- a/css/linkeditor.css
+++ b/css/linkeditor.css
@@ -1,0 +1,21 @@
+.oc-dialog .urlvisit {
+	 margin-bottom: 25px;
+}
+ .oc-dialog .urledit {
+	 padding-left: 10px;
+	 padding-right: 10px;
+	 min-width: 300px;
+	 max-width: 400px;
+}
+ .oc-dialog .urledit.push-bottom {
+	 margin-bottom: 15px;
+}
+ .oc-dialog .urledit .urldisplay {
+	 word-wrap: break-word;
+}
+ .oc-dialog .urledit label {
+	 display: block;
+}
+ .oc-dialog .urledit .space-top {
+	 margin-top: 5px;
+}


### PR DESCRIPTION
The installation of NC25 tries to lookup the css which doesn't exist (only the scss version) so I add a compiled version directly to the package.