### PR TITLE
feat: use native mb_convert_encoding instead of iconv

### DIFF
--- a/lib/Controller/LinkHandlingController.php
+++ b/lib/Controller/LinkHandlingController.php
@@ -107,7 +107,10 @@ class LinkHandlingController extends Controller {
 						// set default encoding if it couldn't be detected
 						$encoding = 'ISO-8859-15';
 					}
-					$fileContents = iconv($encoding, 'UTF-8', $fileContents);
+					if ($encoding !== 'UTF-8') {
+						// convert to UTF-8 if it is not already
+						$fileContents = mb_convert_encoding($fileContents, 'UTF-8', $encoding);
+					}
 					return new DataResponse(
 						[
 							'filecontents' => $fileContents,


### PR DESCRIPTION
Replacing iconv by mb_convert_encoding, see #157 